### PR TITLE
udpated prometheus version to 2.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go get promster
 
 #RUN go test -v promster
 
-
-FROM prom/prometheus:v2.4.0
+FROM prom/prometheus:v2.12.0
 
 ENV LOG_LEVEL 'info'
 


### PR DESCRIPTION
This PR updates the prometheus image version to 2.12.0.

A changelog from 2.4.0 to 2.12.0 can be accessed [here](https://github.com/prometheus/prometheus/releases).

TLDR; numerous performance improvements and bugfixes; subqueries is a new very important feature; No breaking changes;