### PR TITLE
changed source targets structure to add a service name label

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       - EVALUATION_INTERVAL=20s
 
   promster-level2:
-    build: .
     image: flaviostutz/promster
     ports:
       - 9090
@@ -75,7 +74,6 @@ services:
       - EVALUATION_INTERVAL=20s
 
   promster-level3:
-    build: .
     image: flaviostutz/promster
     ports:
       - 9090


### PR DESCRIPTION
This PR improves the source targets structure to add a special service name label called `prsn`.

It's purpose is to add a way to identify the service that is generating a specific metric. The only information we have now is the instance address, which could be misleading.

It also removes unnecessary build tags from the docker-compose.yml file.

Thanks!