### PR TITLE
Relabel instance for prometheus config

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,6 +189,7 @@ func updatePrometheusConfig(prometheusFile string, scrapeInterval string, scrape
 	input["scrapeMatch"] = scrapeMatch
 	input["scheme"] = scheme
 	input["tlsInsecure"] = tlsInsecure
+	input["prometheusServer"] = getSelfNodeName()
 	contents, err := executeTemplate("/", "prometheus.yml.tmpl", input)
 	if err != nil {
 		return err

--- a/prometheus.yml.tmpl
+++ b/prometheus.yml.tmpl
@@ -8,6 +8,11 @@ rule_files:
 
 scrape_configs:
   - job_name: 'prometheus'
+    metric_relabel_configs:
+    - source_labels: ["__name__"]
+      regex: "prometheus_.*"
+      target_label: "instance"
+      replacement: "{{.prometheusServer}}"
     static_configs:
     - targets: ['localhost:9090']
 

--- a/utils.go
+++ b/utils.go
@@ -132,6 +132,9 @@ func unique(intSlice []string) []string {
 func executeTemplate(dir string, templ string, input map[string]interface{}) (string, error) {
 	tmpl := template.New("root")
 	tmpl1, err := tmpl.ParseGlob(dir + "/*.tmpl")
+	if err != nil {
+		return "", err
+	}
 	buf := new(bytes.Buffer)
 	err = tmpl1.ExecuteTemplate(buf, templ, input)
 	if err != nil {


### PR DESCRIPTION
The Prometheus config are setting localhost:9090 as instance labels for every promster container, it causes a deduplication problem on cortex. The pr adds the real IP of promster on template variables so it can use metric relabel config on prometheus config file. 

The metrics will be record as shown in the picture below:

![image](https://user-images.githubusercontent.com/2671806/82077453-d8df9600-96b5-11ea-8a27-39dd47c6d009.png)


Signed-off-by: Gustavo Coelho <gutorc@hotmail.com>