### PR TITLE
Fix arbitrary redirects under the /new endpoint (CVE-2021-29622)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ADD . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/promster
 
 
-FROM prom/prometheus:v2.15.1
+FROM prom/prometheus:v2.27.1
 
 ENV LOG_LEVEL 'info'
 


### PR DESCRIPTION
Update prometheus to version 2.27.1 / 2021-05-18

This release contains a bug fix for a security issue in the API endpoint. An attacker can craft a special URL that redirects a user to any endpoint via an HTTP 302 response. See the security advisory for more details.

Add three new limits to the scrape configuration to provide some
mechanism to defend against unbound number of labels and excessive
label lengths. If any of these limits are broken by a sample from a
scrape, the whole scrape will fail. For all of these configuration
options, a zero value means no limit.